### PR TITLE
Fix/tournament result

### DIFF
--- a/backend-ping-pong/src/common/DuelManager.ts
+++ b/backend-ping-pong/src/common/DuelManager.ts
@@ -16,7 +16,6 @@ export class DuelManager {
     // 점수
     private playerScores: number[] = [0, 0];
 
-
     constructor(
         private players: Player[],
         private whole_players: Player[],

--- a/backend-ping-pong/src/common/DuelManager.ts
+++ b/backend-ping-pong/src/common/DuelManager.ts
@@ -21,7 +21,7 @@ export class DuelManager {
         private players: Player[],
         private whole_players: Player[],
         private currentMatch: number,
-        private onEndDuel: (winner: string, roundScores: number[]) => void,
+        private onEndDuel: (winner: Player, roundScores: number[]) => void,
     ) {
         this.onScore = this.onScore.bind(this);
     }
@@ -36,11 +36,11 @@ export class DuelManager {
     }
 
     private endGame(): void {
-        const finalWinner = this.roundScores[0] > this.roundScores[1] ? this.players[0].username : this.players[1].username;
+        const finalWinner = this.roundScores[0] > this.roundScores[1] ? this.players[0] : this.players[1];
 
         this.broadcast({
             type: "game_end",
-            final_winner: finalWinner,
+            final_winner: finalWinner.username,
         });
 
         this.onEndDuel(finalWinner, this.roundScores);

--- a/backend-ping-pong/src/common/GameResult.ts
+++ b/backend-ping-pong/src/common/GameResult.ts
@@ -1,0 +1,13 @@
+export type GameResult = {
+    game_end_reason: string,
+    player1: {
+        id: string,
+        round_score: number,
+        result: string,
+    },
+    player2: {
+        id: string,
+        round_score: number,
+        result: string,
+    },
+}

--- a/backend-ping-pong/src/common/IMessageBrocker.ts
+++ b/backend-ping-pong/src/common/IMessageBrocker.ts
@@ -1,3 +1,5 @@
+import { GameResult } from "./GameResult";
+
 export interface IMessageBroker {
-    sendGameResult(message: any): void;
+    sendGameResult(message: GameResult[]): void;
 }

--- a/backend-ping-pong/src/duel/GameManager.ts
+++ b/backend-ping-pong/src/duel/GameManager.ts
@@ -18,7 +18,7 @@ export class GameManager implements IGameManager {
         this.duelManager.startGame();
     }
 
-    private onEndDuel(winner: string, roundScores: number[]): void {
+    private onEndDuel(winner: Player, roundScores: number[]): void {
         this.isPlaying = false;
 
         this.messageBroker.sendGameResult([{
@@ -26,12 +26,12 @@ export class GameManager implements IGameManager {
             player1: {
                 id: this.players[0].id,
                 round_score: roundScores[0],
-                result: winner === this.players[0].username ? "winner" : "loser",
+                result: winner.username === this.players[0].username ? "winner" : "loser",
             },
             player2: {
                 id: this.players[1].id,
                 round_score: roundScores[1],
-                result: winner === this.players[1].username ? "winner" : "loser",
+                result: winner.username === this.players[1].username ? "winner" : "loser",
             },
         }]);
     }

--- a/backend-ping-pong/src/duel/GameManager.ts
+++ b/backend-ping-pong/src/duel/GameManager.ts
@@ -21,7 +21,7 @@ export class GameManager implements IGameManager {
     private onEndDuel(winner: string, roundScores: number[]): void {
         this.isPlaying = false;
 
-        this.messageBroker.sendGameResult({
+        this.messageBroker.sendGameResult([{
             game_end_reason: "normal",
             player1: {
                 id: this.players[0].id,
@@ -33,7 +33,7 @@ export class GameManager implements IGameManager {
                 round_score: roundScores[1],
                 result: winner === this.players[1].username ? "winner" : "loser",
             },
-        });
+        }]);
     }
 
     public onMessage(from: Player, message: any): void {
@@ -68,7 +68,7 @@ export class GameManager implements IGameManager {
 
         const remainingPlayer = this.players.find(p => p.id !== disconnectedPlayer.id);
 
-        this.messageBroker.sendGameResult({
+        this.messageBroker.sendGameResult([{
             game_end_reason: "player_disconnected",
             player1: {
                 id: this.players[0].id,
@@ -80,7 +80,7 @@ export class GameManager implements IGameManager {
                 round_score: roundScores[1],
                 result: (remainingPlayer && this.players[1].id === remainingPlayer.id) ? "winner" : "loser",
             },
-        });
+        }]);
 
         return true;
     }

--- a/backend-ping-pong/src/tournament/GameManager.ts
+++ b/backend-ping-pong/src/tournament/GameManager.ts
@@ -4,20 +4,7 @@ import { Player } from "../common/Player";
 import { IMessageBroker } from "../common/IMessageBrocker";
 import { IGameManager } from "../common/IGameManager";
 import { DuelManager } from '../common/DuelManager';
-
-type GameResult = {
-    game_end_reason: string,
-    player1: {
-        id: string,
-        round_score: number,
-        result: string,
-    },
-    player2: {
-        id: string,
-        round_score: number,
-        result: string,
-    },
-}
+import { GameResult } from '../common/GameResult';
 
 export class GameManager implements IGameManager {
     public id: string;

--- a/backend-ping-pong/src/tournament/GameManager.ts
+++ b/backend-ping-pong/src/tournament/GameManager.ts
@@ -135,7 +135,7 @@ export class GameManager implements IGameManager {
 
         const remainingPlayer = this.players.find(p => p.id !== disconnectedPlayer.id);
 
-        this.messageBroker.sendGameResult({
+        this.messageBroker.sendGameResult([{
             game_end_reason: "player_disconnected",
             player1: {
                 id: this.players[0].id,
@@ -147,7 +147,7 @@ export class GameManager implements IGameManager {
                 round_score: roundScores[1],
                 result: (remainingPlayer && this.players[1].id === remainingPlayer.id) ? "winner" : "loser",
             },
-        });
+        }]);
 
         return true;
     }

--- a/backend-ping-pong/src/tournament/GameManager.ts
+++ b/backend-ping-pong/src/tournament/GameManager.ts
@@ -29,12 +29,30 @@ export class GameManager implements IGameManager {
     private currentPlayers: Player[] = [];
 
     constructor(private players: Player[], private messageBroker: IMessageBroker) {
+
+        function shufflePlayers(players: Player[]): Player[] {
+            const shuffled = [...players];
+            for (let i = shuffled.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+            }
+            return shuffled;
+        }
+
+        function initMatches(players: Player[]): Player[][] {
+            const matches: Player[][] = [];
+            for (let i = 0; i < players.length; i += 2) {
+                matches.push([players[i], players[i + 1]]);
+            }
+            return matches;
+        }
+
         this.id = 'duel-' + uuidv4();
         this.isPlaying = true;
         this.onEndRound = this.onEndRound.bind(this);
 
-        this.players = this.shufflePlayers(this.players);
-        this.matches = this.initMatches(this.players);
+        this.players = shufflePlayers(this.players);
+        this.matches = initMatches(this.players);
 
         this.startTournament();
     }
@@ -91,23 +109,6 @@ export class GameManager implements IGameManager {
         this.isPlaying = false;
         this.broadcast({ type: "tournament_end" });
         this.messageBroker.sendGameResult(this.gameResults);
-    }
-
-    private shufflePlayers(players: Player[]): Player[] {
-        const shuffled = [...players];
-        for (let i = shuffled.length - 1; i > 0; i--) {
-            const j = Math.floor(Math.random() * (i + 1));
-            [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-        }
-        return shuffled;
-    }
-
-    private initMatches(players: Player[]): Player[][] {
-        const matches: Player[][] = [];
-        for (let i = 0; i < players.length; i += 2) {
-            matches.push([players[i], players[i + 1]]);
-        }
-        return matches;
     }
 
     public onMessage(from: Player, message: any): void {


### PR DESCRIPTION
# 변경사항
- tournament에서 게임 결과가 잘못 전달되는 버그를 고쳤습니다.
# 참고사항
- `backend-ping-pong` -> `backend-blockchain` tournament 결과 전달 형식 @duckgii 
```json
[
  {
    "game_end_reason": "normal",
    "player1": {
      "id": "player-b5e6038b-3f74-44d7-abfc-6644bcbd12a2",
      "round_score": 3,
      "result": "winner"
    },
    "player2": {
      "id": "player-1c6b8679-04b7-45c1-af8b-cbb699e5f50b",
      "round_score": 0,
      "result": "loser"
    }
  },
  {
    "game_end_reason": "normal",
    "player1": {
      "id": "player-97297a56-2eac-4fac-83bd-a35628a6af8b",
      "round_score": 3,
      "result": "winner"
    },
    "player2": {
      "id": "player-3e0a066d-0d90-4a91-ab28-fe214664116c",
      "round_score": 0,
      "result": "loser"
    }
  },
  {
    "game_end_reason": "normal",
    "player1": {
      "id": "player-b5e6038b-3f74-44d7-abfc-6644bcbd12a2",
      "round_score": 3,
      "result": "winner"
    },
    "player2": {
      "id": "player-97297a56-2eac-4fac-83bd-a35628a6af8b",
      "round_score": 0,
      "result": "loser"
    }
  }
]
```